### PR TITLE
Improved output behaviour

### DIFF
--- a/livy.py
+++ b/livy.py
@@ -53,7 +53,7 @@ class Livy:
     def read(self, dataframe_name):
         code = SERIALISE_DATAFRAME_TEMPLATE.format(dataframe_name)
         output = self._execute(code)
-        if output.status != 'ok':
+        if output.status != OutputStatus.OK:
             raise RuntimeError(f'dataframe serialisation failed: {output}')
         return extract_serialised_dataframe(output.text)
 
@@ -229,6 +229,11 @@ class Statement:
             self.refresh()
             
             
+class OutputStatus(Enum):
+    OK = 'ok'
+    ERROR = 'error'
+
+
 class Output:
     
     def __init__(self, status, text=None, ename=None, traceback=None):
@@ -240,7 +245,7 @@ class Output:
     @classmethod
     def from_json(cls, data):
         return cls(
-            data['status'],
+            OutputStatus(data['status']),
             data.get('data', {}).get('text/plain'),
             data.get('ename'),
             data.get('traceback')

--- a/livy.py
+++ b/livy.py
@@ -236,10 +236,12 @@ class OutputStatus(Enum):
 
 class Output:
     
-    def __init__(self, status, text=None, ename=None, traceback=None):
+    def __init__(self, status, text=None, ename=None, evalue=None,
+                 traceback=None):
         self.status = status
         self.text = text
         self.ename = ename
+        self.evalue = evalue
         self.traceback = traceback
         
     @classmethod
@@ -248,6 +250,7 @@ class Output:
             OutputStatus(data['status']),
             data.get('data', {}).get('text/plain'),
             data.get('ename'),
+            data.get('evalue'),
             data.get('traceback')
         )
         


### PR DESCRIPTION
By default, print output from the Spark session and raise exceptions on errors. Both these behaviours can be disabled by setting the respective `echo` and `check` arguments to `Livy()` to `False`.