### PR TITLE
Separate models and logic

### DIFF
--- a/it/test_integration.py
+++ b/it/test_integration.py
@@ -57,7 +57,7 @@ def test_spark(capsys):
         expected = pandas.DataFrame({'value': range(100)})
         assert client.read('df').equals(expected)
 
-        session_id = client.session.id_
+        session_id = client.session_id
 
     assert run_sync(session_stopped(session_id))
 
@@ -87,7 +87,7 @@ def test_pyspark(capsys):
         expected = pandas.DataFrame({'value': range(100)})
         assert client.read('df').equals(expected)
 
-        session_id = client.session.id_
+        session_id = client.session_id
 
     assert run_sync(session_stopped(session_id))
 
@@ -116,7 +116,7 @@ def test_sparkr(capsys):
         expected = pandas.DataFrame({'value': range(100)})
         assert client.read('df').equals(expected)
 
-        session_id = client.session.id_
+        session_id = client.session_id
 
     assert run_sync(session_stopped(session_id))
 
@@ -139,6 +139,6 @@ def test_sql():
         with pytest.raises(SparkRuntimeError):
             client.run('not valid SQL!')
 
-        session_id = client.session.id_
+        session_id = client.session_id
 
     assert run_sync(session_stopped(session_id))


### PR DESCRIPTION
This PR makes all the models immutable (they're all `typing.NamedTuple`, with some added deserialisation logic) and puts all the request logic into a single client class. This makes it much easier to reason about the life cycle of the aiohttp client session object.