### PR TITLE
Session ready in enter

### DIFF
--- a/it/test_integration.py
+++ b/it/test_integration.py
@@ -122,9 +122,7 @@ def test_session_sync(capsys, session_kind, params):
         expected = pandas.DataFrame({'value': range(100)})
         assert session.read('df').equals(expected)
 
-        session_id = session.session_id
-
-    assert run_sync(session_stopped(session_id))
+    assert run_sync(session_stopped(session.session_id))
 
 
 @pytest.mark.parametrize('session_kind, params', [
@@ -156,9 +154,7 @@ async def test_session_async(capsys, session_kind, params):
         expected = pandas.DataFrame({'value': range(100)})
         assert (await session.read('df')).equals(expected)
 
-        session_id = session.session_id
-
-    await session_stopped(session_id)
+    assert await session_stopped(session.session_id)
 
 
 SQL_CREATE_VIEW = """
@@ -181,9 +177,7 @@ def test_sql_session_sync():
         with pytest.raises(SparkRuntimeError):
             session.run('not valid SQL!')
 
-        session_id = session.session_id
-
-    assert run_sync(session_stopped(session_id))
+    assert run_sync(session_stopped(session.session_id))
 
 
 @pytest.mark.asyncio
@@ -202,6 +196,4 @@ async def test_sql_session_async():
         with pytest.raises(SparkRuntimeError):
             await session.run('not valid SQL!')
 
-        session_id = session.session_id
-
-    assert await session_stopped(session_id)
+    assert await session_stopped(session.session_id)

--- a/it/test_integration.py
+++ b/it/test_integration.py
@@ -5,7 +5,9 @@ import pytest
 import aiohttp
 import pandas
 
-from livy import LivySession, AsyncLivySession, SessionKind, SparkRuntimeError
+from livy import (
+    LivySession, AsyncLivySession, SessionKind, SparkRuntimeError, SessionState
+)
 from livy.session import run_sync
 
 
@@ -103,6 +105,8 @@ def test_session_sync(capsys, session_kind, params):
 
     with LivySession(LIVY_URL, kind=session_kind) as session:
 
+        assert session.state == SessionState.IDLE
+
         session.run(params.print_foo_code)
         assert capsys.readouterr() == (params.print_foo_output, '')
 
@@ -135,6 +139,8 @@ async def test_session_async(capsys, session_kind, params):
 
     async with AsyncLivySession(LIVY_URL, kind=session_kind) as session:
 
+        assert (await session.state) == SessionState.IDLE
+
         await session.run(params.print_foo_code)
         assert capsys.readouterr() == (params.print_foo_output, '')
 
@@ -166,6 +172,8 @@ def test_sql_session_sync():
 
     with LivySession(LIVY_URL, kind=SessionKind.SQL) as session:
 
+        assert session.state == SessionState.IDLE
+
         session.run(SQL_CREATE_VIEW)
         output = session.run('SELECT COUNT(*) FROM view')
         assert output.json['data'] == [[100]]
@@ -184,6 +192,8 @@ async def test_sql_session_async():
     assert await livy_available()
 
     async with AsyncLivySession(LIVY_URL, kind=SessionKind.SQL) as session:
+
+        assert (await session.state) == SessionState.IDLE
 
         await session.run(SQL_CREATE_VIEW)
         output = await session.run('SELECT COUNT(*) FROM view')

--- a/livy/__init__.py
+++ b/livy/__init__.py
@@ -1,2 +1,4 @@
 from livy.session import LivySession, AsyncLivySession  # noqa: F401
-from livy.models import SessionKind, SparkRuntimeError  # noqa: F401
+from livy.models import (  # noqa: F401
+    SessionKind, SessionState, SparkRuntimeError
+)

--- a/livy/session.py
+++ b/livy/session.py
@@ -4,11 +4,7 @@ import asyncio
 
 import pandas
 
-from livy.models import (  # noqa: F401
-    Session, SessionKind, SessionState,
-    Statement, StatementState,
-    SparkRuntimeError
-)
+from livy.models import SessionKind, SessionState, StatementState
 from livy.client import LivyClient
 
 


### PR DESCRIPTION
Consider the flow through a block like:

```python
with LivySession(url) as session:
    print('foo')
    session.run('print("bar")')
```

Currently, the Spark session would be created on the first `session.run()`. This PR changes it so that the session gets created before entering the `with` block, i.e. before the `print('foo')`.