### PR TITLE
Added PYSPARK3 to valid sessions

### DIFF
--- a/livy/session.py
+++ b/livy/session.py
@@ -25,6 +25,7 @@ def serialise_dataframe_code(
         template = {
             SessionKind.SPARK: SERIALISE_DATAFRAME_TEMPLATE_SPARK,
             SessionKind.PYSPARK: SERIALISE_DATAFRAME_TEMPLATE_PYSPARK,
+            SessionKind.PYSPARK3: SERIALISE_DATAFRAME_TEMPLATE_PYSPARK,
             SessionKind.SPARKR: SERIALISE_DATAFRAME_TEMPLATE_SPARKR
         }[session_kind]
     except KeyError:


### PR DESCRIPTION
I was getting `RuntimeError: read not supported for sessions of kind SessionKind.PYSPARK3`

This seems to fix it.