### PR TITLE
Add ability to pass additional parameters when creating the session

### DIFF
--- a/livy/client.py
+++ b/livy/client.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Optional, List
+from typing import Any, Dict, List, Optional
 
 import requests
 
@@ -69,8 +69,9 @@ class LivyClient:
         data = self._client.get('/sessions')
         return [Session.from_json(item) for item in data['sessions']]
 
-    def create_session(self, kind: SessionKind) -> Session:
-
+    def create_session(
+            self, kind: SessionKind, spark_conf: Dict[str, Any]=None
+    ) -> Session:
         if self.legacy_server():
             valid_kinds = VALID_LEGACY_SESSION_KINDS
         else:
@@ -82,7 +83,11 @@ class LivyClient:
                 f'this version (should be one of {valid_kinds})'
             )
 
-        data = self._client.post('/sessions', data={'kind': kind.value})
+        body = {'kind': kind.value}
+        if spark_conf is not None:
+            body['conf'] = spark_conf
+
+        data = self._client.post('/sessions', data=body)
         return Session.from_json(data)
 
     def get_session(self, session_id: int) -> Optional[Session]:

--- a/livy/session.py
+++ b/livy/session.py
@@ -1,6 +1,6 @@
 import time
 import json
-from typing import Iterable, Iterator, Optional
+from typing import Any, Dict, Iterable, Iterator, Optional
 
 import pandas
 
@@ -74,13 +74,14 @@ class LivySession:
 
     def __init__(
         self, url: str, kind: SessionKind=SessionKind.PYSPARK,
-        echo: bool=True, check: bool=True
+        spark_conf: Dict[str, Any]=None, echo: bool=True, check: bool=True
     ) -> None:
         self.client = LivyClient(url)
         self.kind = kind
         self.echo = echo
         self.check = check
         self.session_id: Optional[int] = None
+        self.spark_conf = spark_conf
 
     def __enter__(self) -> 'LivySession':
         self.start()
@@ -90,7 +91,7 @@ class LivySession:
         self.close()
 
     def start(self) -> None:
-        session = self.client.create_session(self.kind)
+        session = self.client.create_session(self.kind, self.spark_conf)
         self.session_id = session.session_id
 
         not_ready = {SessionState.NOT_STARTED, SessionState.STARTING}

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -13,6 +13,10 @@ MOCK_SESSION_ID = 5
 MOCK_STATEMENT_JSON = {'mock': 'statement'}
 MOCK_STATEMENT_ID = 12
 MOCK_CODE = 'mock code'
+MOCK_SPARK_CONF = {
+    "spark.master": "yarn",
+    "spark.submit.deployMode": "client"
+}
 
 
 def mock_livy_server():
@@ -33,7 +37,10 @@ def mock_livy_server():
 
     @app.route('/sessions', methods=['POST'])
     def create_session():
-        assert request.get_json() == {'kind': 'pyspark'}
+        assert request.get_json() == {
+            'kind': 'pyspark',
+            'conf': MOCK_SPARK_CONF
+        }
         return jsonify(MOCK_SESSION_JSON)
 
     @app.route(f'/sessions/{MOCK_SESSION_ID}', methods=['DELETE'])
@@ -92,7 +99,10 @@ def test_create_session(mocker, server):
     mocker.patch.object(Session, 'from_json')
 
     client = LivyClient(server)
-    session = client.create_session(SessionKind.PYSPARK)
+    session = client.create_session(
+        SessionKind.PYSPARK,
+        spark_conf=MOCK_SPARK_CONF
+    )
 
     assert session == Session.from_json.return_value
     Session.from_json.assert_called_once_with(MOCK_SESSION_JSON)


### PR DESCRIPTION
We had a need to pass additional parameters when creating the session.  Specifically, the 'conf' parameter for spark configuration properties.

See POST /sessions [here](https://livy.incubator.apache.org/docs/latest/rest-api.html).