### PR TITLE
Use dataclasses instead of named tuples

### DIFF
--- a/it/test_integration.py
+++ b/it/test_integration.py
@@ -1,5 +1,5 @@
 import os
-from collections import namedtuple
+from dataclasses import dataclass
 
 import pytest
 import requests
@@ -25,17 +25,14 @@ def session_stopped(session_id):
         return response.get_json()['state'] == 'shutting_down'
 
 
-Parameters = namedtuple(
-    'Parameters',
-    [
-        'print_foo_code',
-        'print_foo_output',
-        'create_dataframe_code',
-        'dataframe_count_code',
-        'dataframe_count_output',
-        'error_code'
-    ]
-)
+@dataclass
+class Parameters:
+    print_foo_code: str
+    print_foo_output: str
+    create_dataframe_code: str
+    dataframe_count_code: str
+    dataframe_count_output: str
+    error_code: str
 
 
 SPARK_CREATE_DF = """

--- a/livy/models.py
+++ b/livy/models.py
@@ -1,7 +1,8 @@
 import re
+from dataclasses import dataclass
 from enum import Enum
 from functools import total_ordering
-from typing import NamedTuple, Optional, List
+from typing import Optional, List
 
 
 @total_ordering
@@ -64,7 +65,8 @@ class OutputStatus(Enum):
     ERROR = "error"
 
 
-class Output(NamedTuple):
+@dataclass
+class Output:
     status: OutputStatus
     text: Optional[str]
     json: Optional[dict]
@@ -104,7 +106,8 @@ class StatementState(Enum):
     CANCELLED = "cancelled"
 
 
-class Statement(NamedTuple):
+@dataclass
+class Statement:
     session_id: int
     statement_id: int
     state: StatementState
@@ -141,7 +144,8 @@ class SessionState(Enum):
     SUCCESS = "success"
 
 
-class Session(NamedTuple):
+@dataclass
+class Session:
     session_id: int
     proxy_user: str
     kind: SessionKind

--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,7 @@ setup(
         'it': IntegrationTests
     },
     install_requires=[
+        "dataclasses; python_version<'3.7'",
         'requests',
         'pandas'
     ],


### PR DESCRIPTION
On Python 3.6, use the dataclass backport