### PR TITLE
Clarify supported python versions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,6 +7,9 @@ pylivy
 .. image:: https://badge.fury.io/py/livy.svg
     :target: https://pypi.org/project/livy/
 
+.. image:: https://img.shields.io/pypi/pyversions/livy.svg
+    :target: https://pypi.org/project/livy/
+
 `Livy <https://livy.incubator.apache.org/>`_ is an open source REST interface
 for interacting with `Spark <http://spark.apache.org/>`_. ``pylivy`` is a
 Python client for Livy, enabling easy remote code execution on a Spark cluster.
@@ -17,6 +20,8 @@ Installation
 .. code:: bash
 
     $ pip install -U livy
+
+Note that ``pylivy`` requires Python 3.6 or later.
 
 Documentation
 -------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -18,6 +18,8 @@ Installation
 
     $ pip install -U livy
 
+Note that ``pylivy`` requires Python 3.6 or later.
+
 Usage
 -----
 

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,8 @@ setup(
     classifiers=[
         "License :: OSI Approved :: MIT License",
         "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
     ],
     setup_requires=["wheel"],
     cmdclass={"test": UnitTests, "it": IntegrationTests},


### PR DESCRIPTION
Issue #48 highlighted that the versions of Python supported by this library (which is relatively restrictive) are not clear.

This PR adds a badge and entries to the README and docs to state the supported versions.