### PR TITLE
Remove universal wheel

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,6 +3,3 @@ license_file = LICENSE
 
 [aliases]
 release = sdist bdist_wheel upload
-
-[bdist_wheel]
-universal = true


### PR DESCRIPTION
pylivy is not Python 2 compatible so should not build a universal wheel.