### PR TITLE
Add session arguments

### DIFF
--- a/livy/client.py
+++ b/livy/client.py
@@ -100,12 +100,14 @@ class LivyClient:
         self,
         kind: SessionKind,
         proxy_user: str = None,
+        jars: list() = None,
         spark_conf: Dict[str, Any] = None,
     ) -> Session:
         """Create a new session in Livy.
 
         :param kind: The kind of session to create.
         :param proxy_user: User to impersonate when starting the session.
+        :param jars: jars to be used in this session
         :param spark_conf: Spark configuration properties.
         """
         if self.legacy_server():
@@ -122,6 +124,8 @@ class LivyClient:
         body = {"kind": kind.value}
         if proxy_user is not None:
             body["proxyUser"] = proxy_user
+        if jars is not None:
+            body["jars"] = jars
         if spark_conf is not None:
             body["conf"] = spark_conf
 

--- a/livy/client.py
+++ b/livy/client.py
@@ -101,6 +101,16 @@ class LivyClient:
         kind: SessionKind,
         proxy_user: str = None,
         jars: list() = None,
+        py_files: list() = None,
+        files: list() = None,
+        driver_memory: str = None,
+        driver_cores: int = None,
+        executor_memory: str = None,
+        executor_cores: int = None,
+        num_executors: int = None,
+        archives: list() = None,
+        queue: str = None,
+        name: str = None,
         spark_conf: Dict[str, Any] = None,
     ) -> Session:
         """Create a new session in Livy.
@@ -108,6 +118,16 @@ class LivyClient:
         :param kind: The kind of session to create.
         :param proxy_user: User to impersonate when starting the session.
         :param jars: jars to be used in this session
+        :param py_files: Python files to be used in this session
+        :param files: files to be used in this session
+        :param driver_memory: Amount of memory to use for the driver process
+        :param driver_cores: Number of cores to use for the driver process
+        :param executor_memory: Amount of memory to use per executor process
+        :param executor_cores: Number of cores to use for each executor
+        :param num_executor: Number of executors to launch for this session
+        :param archives: Archives to be used in this session
+        :param queue: The name of the YARN queue to which submitted
+        :param name: The name of this session
         :param spark_conf: Spark configuration properties.
         """
         if self.legacy_server():
@@ -126,6 +146,26 @@ class LivyClient:
             body["proxyUser"] = proxy_user
         if jars is not None:
             body["jars"] = jars
+        if py_files is not None:
+            body["pyFiles"] = py_files
+        if files is not None:
+            body["files"] = files
+        if driver_memory is not None:
+            body["driverMemory"] = driver_memory
+        if driver_cores is not None:
+            body["driverCores"] = driver_cores
+        if executor_memory is not None:
+            body["executorMemory"] = executor_memory
+        if executor_cores is not None:
+            body["executorCores"] = executor_cores
+        if num_executors is not None:
+            body["numExecutors"] = num_executors
+        if archives is not None:
+            body["archives"] = archives
+        if queue is not None:
+            body["queue"] = queue
+        if name is not None:
+            body["name"] = name
         if spark_conf is not None:
             body["conf"] = spark_conf
 

--- a/livy/client.py
+++ b/livy/client.py
@@ -115,19 +115,41 @@ class LivyClient:
     ) -> Session:
         """Create a new session in Livy.
 
+        The py_files, files, jars and archives arguments are lists of URLs,
+        eg: ['s3://bucket/object', 'hdfs://path/to/file', ...] and must be
+        reachable by the Spark driver process.  If the provided URL has no
+        scheme, it's considered to be relative to the default file system
+        configured in the Livy server.
+
+        URLs in the py_files argument are copied to a temporary staging area
+        and inserted into Python's sys.path ahead of the standard library
+        paths.  This allows you to import .py, .zip and .egg files in Python.
+
+        URLs for jars, py_files, files and archives arguments are all copied
+        to the same working directory on the Spark cluster.
+
+        The driver_memory and executor_memory arguments have the same format
+        as JVM memory strings with a size unit suffix ("k", "m", "g" or "t")
+        (e.g. 512m, 2g).
+
+        See https://spark.apache.org/docs/latest/configuration.html for more
+        information on Spark configuration properties.
+
         :param kind: The kind of session to create.
         :param proxy_user: User to impersonate when starting the session.
-        :param jars: jars to be used in this session
-        :param py_files: Python files to be used in this session
-        :param files: files to be used in this session
+        :param jars: URLs of jars to be used in this session.
+        :param py_files: URLs of Python files to be used in this session.
+        :param files: URLs of files to be used in this session.
         :param driver_memory: Amount of memory to use for the driver process
-        :param driver_cores: Number of cores to use for the driver process
+            (eg: '512m').
+        :param driver_cores: Number of cores to use for the driver process.
         :param executor_memory: Amount of memory to use per executor process
-        :param executor_cores: Number of cores to use for each executor
-        :param num_executors: Number of executors to launch for this session
-        :param archives: Archives to be used in this session
-        :param queue: The name of the YARN queue to which submitted
-        :param name: The name of this session
+            (eg: '512m').
+        :param executor_cores: Number of cores to use for each executor.
+        :param num_executors: Number of executors to launch for this session.
+        :param archives: URLs of archives to be used in this session.
+        :param queue: The name of the YARN queue to which submitted.
+        :param name: The name of this session.
         :param spark_conf: Spark configuration properties.
         """
         if self.legacy_server():

--- a/livy/client.py
+++ b/livy/client.py
@@ -100,15 +100,15 @@ class LivyClient:
         self,
         kind: SessionKind,
         proxy_user: str = None,
-        jars: list() = None,
-        py_files: list() = None,
-        files: list() = None,
+        jars: List[str] = None,
+        py_files: List[str] = None,
+        files: List[str] = None,
         driver_memory: str = None,
         driver_cores: int = None,
         executor_memory: str = None,
         executor_cores: int = None,
         num_executors: int = None,
-        archives: list() = None,
+        archives: List[str] = None,
         queue: str = None,
         name: str = None,
         spark_conf: Dict[str, Any] = None,
@@ -124,7 +124,7 @@ class LivyClient:
         :param driver_cores: Number of cores to use for the driver process
         :param executor_memory: Amount of memory to use per executor process
         :param executor_cores: Number of cores to use for each executor
-        :param num_executor: Number of executors to launch for this session
+        :param num_executors: Number of executors to launch for this session
         :param archives: Archives to be used in this session
         :param queue: The name of the YARN queue to which submitted
         :param name: The name of this session

--- a/livy/client.py
+++ b/livy/client.py
@@ -116,7 +116,7 @@ class LivyClient:
         """Create a new session in Livy.
 
         The py_files, files, jars and archives arguments are lists of URLs,
-        eg: ['s3://bucket/object', 'hdfs://path/to/file', ...] and must be
+        e.g. ["s3://bucket/object", "hdfs://path/to/file", ...] and must be
         reachable by the Spark driver process.  If the provided URL has no
         scheme, it's considered to be relative to the default file system
         configured in the Livy server.
@@ -141,10 +141,10 @@ class LivyClient:
         :param py_files: URLs of Python files to be used in this session.
         :param files: URLs of files to be used in this session.
         :param driver_memory: Amount of memory to use for the driver process
-            (eg: '512m').
+            (e.g. '512m').
         :param driver_cores: Number of cores to use for the driver process.
         :param executor_memory: Amount of memory to use per executor process
-            (eg: '512m').
+            (e.g. '512m').
         :param executor_cores: Number of cores to use for each executor.
         :param num_executors: Number of executors to launch for this session.
         :param archives: URLs of archives to be used in this session.

--- a/livy/session.py
+++ b/livy/session.py
@@ -76,6 +76,16 @@ class LivySession:
     :param kind: The kind of session to create.
     :param proxy_user: User to impersonate when starting the session.
     :param jars: jars to be used in this session
+    :param py_files: Python files to be used in this session
+    :param files: files to be used in this session
+    :param driver_memory: Amount of memory to use for the driver process
+    :param driver_cores: Number of cores to use for the driver process
+    :param executor_memory: Amount of memory to use per executor process
+    :param executor_cores: Number of cores to use for each executor
+    :param num_executor: Number of executors to launch for this session
+    :param archives: Archives to be used in this session
+    :param queue: The name of the YARN queue to which submitted
+    :param name: The name of this session
     :param spark_conf: Spark configuration properties.
     :param echo: Whether to echo output printed in the remote session. Defaults
         to ``True``.
@@ -90,6 +100,16 @@ class LivySession:
         kind: SessionKind = SessionKind.PYSPARK,
         proxy_user: str = None,
         jars: list() = None,
+        py_files: list() = None,
+        files: list() = None,
+        driver_memory: str = None,
+        driver_cores: int = None,
+        executor_memory: str = None,
+        executor_cores: int = None,
+        num_executors: int = None,
+        archives: list() = None,
+        queue: str = None,
+        name: str = None,
         spark_conf: Dict[str, Any] = None,
         echo: bool = True,
         check: bool = True,
@@ -98,6 +118,16 @@ class LivySession:
         self.kind = kind
         self.proxy_user = proxy_user
         self.jars = jars
+        self.py_files = py_files
+        self.files = files
+        self.driver_memory = driver_memory
+        self.driver_cores = driver_cores
+        self.executor_memory = executor_memory
+        self.executor_cores = executor_cores
+        self.num_executors = num_executors
+        self.archives = archives
+        self.queue = queue
+        self.name = name
         self.spark_conf = spark_conf
         self.echo = echo
         self.check = check
@@ -114,7 +144,7 @@ class LivySession:
         """Create the remote Spark session and wait for it to be ready."""
 
         session = self.client.create_session(
-            self.kind, self.proxy_user, self.jars, self.spark_conf
+            self.kind, self.proxy_user, self.jars, self.py_files, self.files, self.driver_memory, self.driver_cores, self.executor_memory, self.executor_cores, self.num_executors, self.archives, self.queue, self.name, self.spark_conf
         )
         self.session_id = session.session_id
 

--- a/livy/session.py
+++ b/livy/session.py
@@ -75,6 +75,7 @@ class LivySession:
     :param url: The URL of the Livy server.
     :param kind: The kind of session to create.
     :param proxy_user: User to impersonate when starting the session.
+    :param jars: jars to be used in this session
     :param spark_conf: Spark configuration properties.
     :param echo: Whether to echo output printed in the remote session. Defaults
         to ``True``.
@@ -88,6 +89,7 @@ class LivySession:
         auth: Auth = None,
         kind: SessionKind = SessionKind.PYSPARK,
         proxy_user: str = None,
+        jars: list() = None,
         spark_conf: Dict[str, Any] = None,
         echo: bool = True,
         check: bool = True,
@@ -95,6 +97,7 @@ class LivySession:
         self.client = LivyClient(url, auth)
         self.kind = kind
         self.proxy_user = proxy_user
+        self.jars = jars
         self.spark_conf = spark_conf
         self.echo = echo
         self.check = check
@@ -111,7 +114,7 @@ class LivySession:
         """Create the remote Spark session and wait for it to be ready."""
 
         session = self.client.create_session(
-            self.kind, self.proxy_user, self.spark_conf
+            self.kind, self.proxy_user, self.jars, self.spark_conf
         )
         self.session_id = session.session_id
 

--- a/livy/session.py
+++ b/livy/session.py
@@ -1,6 +1,6 @@
 import time
 import json
-from typing import Any, Dict, Iterable, Iterator, Optional
+from typing import Any, Dict, List, Iterable, Iterator, Optional
 
 import pandas
 
@@ -82,7 +82,7 @@ class LivySession:
     :param driver_cores: Number of cores to use for the driver process
     :param executor_memory: Amount of memory to use per executor process
     :param executor_cores: Number of cores to use for each executor
-    :param num_executor: Number of executors to launch for this session
+    :param num_executors: Number of executors to launch for this session
     :param archives: Archives to be used in this session
     :param queue: The name of the YARN queue to which submitted
     :param name: The name of this session
@@ -99,15 +99,15 @@ class LivySession:
         auth: Auth = None,
         kind: SessionKind = SessionKind.PYSPARK,
         proxy_user: str = None,
-        jars: list() = None,
-        py_files: list() = None,
-        files: list() = None,
+        jars: List[str] = None,
+        py_files: List[str] = None,
+        files: List[str] = None,
         driver_memory: str = None,
         driver_cores: int = None,
         executor_memory: str = None,
         executor_cores: int = None,
         num_executors: int = None,
-        archives: list() = None,
+        archives: List[str] = None,
         queue: str = None,
         name: str = None,
         spark_conf: Dict[str, Any] = None,
@@ -144,7 +144,20 @@ class LivySession:
         """Create the remote Spark session and wait for it to be ready."""
 
         session = self.client.create_session(
-            self.kind, self.proxy_user, self.jars, self.py_files, self.files, self.driver_memory, self.driver_cores, self.executor_memory, self.executor_cores, self.num_executors, self.archives, self.queue, self.name, self.spark_conf
+            self.kind,
+            self.proxy_user,
+            self.jars,
+            self.py_files,
+            self.files,
+            self.driver_memory,
+            self.driver_cores,
+            self.executor_memory,
+            self.executor_cores,
+            self.num_executors,
+            self.archives,
+            self.queue,
+            self.name,
+            self.spark_conf,
         )
         self.session_id = session.session_id
 

--- a/livy/session.py
+++ b/livy/session.py
@@ -72,20 +72,42 @@ def polling_intervals(
 class LivySession:
     """Manages a remote Livy session and high-level interactions with it.
 
+    The py_files, files, jars and archives arguments are lists of URLs, e.g.
+    ["s3://bucket/object", "hdfs://path/to/file", ...] and must be reachable by
+    the Spark driver process.  If the provided URL has no scheme, it's
+    considered to be relative to the default file system configured in the Livy
+    server.
+
+    URLs in the py_files argument are copied to a temporary staging area and
+    inserted into Python's sys.path ahead of the standard library paths. This
+    allows you to import .py, .zip and .egg files in Python.
+
+    URLs for jars, py_files, files and archives arguments are all copied to the
+    same working directory on the Spark cluster.
+
+    The driver_memory and executor_memory arguments have the same format as JVM
+    memory strings with a size unit suffix ("k", "m", "g" or "t") (e.g. 512m,
+    2g).
+
+    See https://spark.apache.org/docs/latest/configuration.html for more
+    information on Spark configuration properties.
+
     :param url: The URL of the Livy server.
     :param kind: The kind of session to create.
     :param proxy_user: User to impersonate when starting the session.
-    :param jars: jars to be used in this session
-    :param py_files: Python files to be used in this session
-    :param files: files to be used in this session
-    :param driver_memory: Amount of memory to use for the driver process
-    :param driver_cores: Number of cores to use for the driver process
-    :param executor_memory: Amount of memory to use per executor process
-    :param executor_cores: Number of cores to use for each executor
-    :param num_executors: Number of executors to launch for this session
-    :param archives: Archives to be used in this session
-    :param queue: The name of the YARN queue to which submitted
-    :param name: The name of this session
+    :param jars: URLs of jars to be used in this session.
+    :param py_files: URLs of Python files to be used in this session.
+    :param files: URLs of files to be used in this session.
+    :param driver_memory: Amount of memory to use for the driver process (e.g.
+        '512m').
+    :param driver_cores: Number of cores to use for the driver process.
+    :param executor_memory: Amount of memory to use per executor process (e.g.
+        '512m').
+    :param executor_cores: Number of cores to use for each executor.
+    :param num_executors: Number of executors to launch for this session.
+    :param archives: URLs of archives to be used in this session.
+    :param queue: The name of the YARN queue to which submitted.
+    :param name: The name of this session.
     :param spark_conf: Spark configuration properties.
     :param echo: Whether to echo output printed in the remote session. Defaults
         to ``True``.

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -9,6 +9,17 @@ MOCK_STATEMENT_ID = 12
 MOCK_CODE = "mock code"
 MOCK_PROXY_USER = "proxy-user"
 MOCK_SPARK_CONF = {"spark.master": "yarn", "spark.submit.deployMode": "client"}
+MOCK_JARS = ["mock1.jar", "mock2.jar"]
+MOCK_PY_FILES = ["mock1.py", "mock2.py"]
+MOCK_FILES = ["mockfile1.txt", "mockfile2.txt"]
+MOCK_DRIVER_MEMORY = ""
+MOCK_DRIVER_CORES = 2
+MOCK_EXECUTOR_MEMORY = ""
+MOCK_EXECUTOR_CORES = 4
+MOCK_NUM_EXECUTORS = 6
+MOCK_ARCHIVES = ["mock1.tar.gz", "mock2.tar.gz"]
+MOCK_QUEUE = "mock-queue"
+MOCK_NAME = "mock-session-name"
 
 
 def test_list_sessions(requests_mock, mocker):
@@ -50,6 +61,17 @@ def test_create_session(requests_mock, mocker):
         SessionKind.PYSPARK,
         proxy_user=MOCK_PROXY_USER,
         spark_conf=MOCK_SPARK_CONF,
+        jars=MOCK_JARS,
+        py_files=MOCK_PY_FILES,
+        files=MOCK_FILES,
+        driver_memory=MOCK_DRIVER_MEMORY,
+        driver_cores=MOCK_DRIVER_CORES,
+        executor_memory=MOCK_EXECUTOR_MEMORY,
+        executor_cores=MOCK_EXECUTOR_CORES,
+        num_executors=MOCK_NUM_EXECUTORS,
+        archives=MOCK_ARCHIVES,
+        queue=MOCK_QUEUE,
+        name=MOCK_NAME
     )
 
     assert session == Session.from_json.return_value
@@ -58,6 +80,17 @@ def test_create_session(requests_mock, mocker):
         "kind": "pyspark",
         "proxyUser": MOCK_PROXY_USER,
         "conf": MOCK_SPARK_CONF,
+        "jars": MOCK_JARS,
+        "pyFiles": MOCK_PY_FILES,
+        "files": MOCK_FILES,
+        "driverMemory": MOCK_DRIVER_MEMORY,
+        "driverCores": MOCK_DRIVER_CORES,
+        "executorMemory": MOCK_EXECUTOR_MEMORY,
+        "executorCores": MOCK_EXECUTOR_CORES,
+        "numExecutors": MOCK_NUM_EXECUTORS,
+        "archives": MOCK_ARCHIVES,
+        "queue": MOCK_QUEUE,
+        "name": MOCK_NAME
     }
 
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -12,9 +12,9 @@ MOCK_SPARK_CONF = {"spark.master": "yarn", "spark.submit.deployMode": "client"}
 MOCK_JARS = ["mock1.jar", "mock2.jar"]
 MOCK_PY_FILES = ["mock1.py", "mock2.py"]
 MOCK_FILES = ["mockfile1.txt", "mockfile2.txt"]
-MOCK_DRIVER_MEMORY = ""
+MOCK_DRIVER_MEMORY = "512m"
 MOCK_DRIVER_CORES = 2
-MOCK_EXECUTOR_MEMORY = ""
+MOCK_EXECUTOR_MEMORY = "1024m"
 MOCK_EXECUTOR_CORES = 4
 MOCK_NUM_EXECUTORS = 6
 MOCK_ARCHIVES = ["mock1.tar.gz", "mock2.tar.gz"]
@@ -71,7 +71,7 @@ def test_create_session(requests_mock, mocker):
         num_executors=MOCK_NUM_EXECUTORS,
         archives=MOCK_ARCHIVES,
         queue=MOCK_QUEUE,
-        name=MOCK_NAME
+        name=MOCK_NAME,
     )
 
     assert session == Session.from_json.return_value
@@ -90,7 +90,7 @@ def test_create_session(requests_mock, mocker):
         "numExecutors": MOCK_NUM_EXECUTORS,
         "archives": MOCK_ARCHIVES,
         "queue": MOCK_QUEUE,
-        "name": MOCK_NAME
+        "name": MOCK_NAME,
     }
 
 


### PR DESCRIPTION
This pull request adds missing options for the Session object (eg: pyFiles, files, archives, etc) as defined in the Livy documentation (https://livy.incubator.apache.org/docs/latest/rest-api.html).  My project requires the pyFiles argument to reference additional Python modules available on S3.  I think this enhancement would be of use to many people in the Python/Livy community.

This is based on #47 and #34, rebased on the latest commit of the master branch and updated to resolve issues with mypy and black.  There is no additional logic, just passing arguments to the Livy request.  I have tested the py_files option on a Spark EMR v2.4.0 running Livy v0.5.0 and it worked as expected.

Thanks to Parisni for his work on the original PR.