### PR TITLE
Add a verify option for certificate management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,3 @@ dist/
 livy.egg-info/
 .pytest_cache/
 .tox/
-.idea

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist/
 livy.egg-info/
 .pytest_cache/
 .tox/
+.idea

--- a/AUTHORS
+++ b/AUTHORS
@@ -7,3 +7,4 @@ Contributions have been provided by:
 - Chris LeBlanc (@crleblanc)
 - Jon Nalley (@jnalley)
 - Nicolas Paris (@parisni)
+- Chris Arnault (@ChristianArnault)

--- a/livy/client.py
+++ b/livy/client.py
@@ -58,15 +58,7 @@ class JsonClient:
 
     def _request(self, method: str, endpoint: str, data: dict = None) -> dict:
         url = self.url.rstrip("/") + endpoint
-        response = self.session.request(
-            method,
-            url,
-            json=data,
-            auth=self.session.auth,
-            headers=self.session.headers,
-            params=self.session.params,
-            verify=self.session.verify,
-        )
+        response = self.session.request(method, url, json=data)
         response.raise_for_status()
         return response.json()
 

--- a/livy/client.py
+++ b/livy/client.py
@@ -38,6 +38,7 @@ class JsonClient:
     def __init__(self, url: str, auth: Auth = None) -> None:
         self.url = url
         self.session = requests.Session()
+        self.session.verify = False
         if auth is not None:
             self.session.auth = auth
 
@@ -55,7 +56,12 @@ class JsonClient:
 
     def _request(self, method: str, endpoint: str, data: dict = None) -> dict:
         url = self.url.rstrip("/") + endpoint
-        response = self.session.request(method, url, json=data)
+        response = self.session.request(method, url,
+                                        json=data,
+                                        auth=self.session.auth,
+                                        headers=self.session.headers,
+                                        params=self.session.params,
+                                        verify=self.session.verify)
         response.raise_for_status()
         return response.json()
 

--- a/livy/client.py
+++ b/livy/client.py
@@ -76,7 +76,8 @@ class LivyClient:
 
     :param url: The URL of the Livy server.
     :param auth: A requests-compatible auth object to use when making requests.
-    :param verify_ssl: This option is used when SSL authentication is used, and the existence of the certificate
+    :param verify_ssl: This option is used when SSL authentication is used,
+        and the existence of the certificate
         must be verified or certified with some certification authority.
         Defaults to ``False``.
     """

--- a/livy/client.py
+++ b/livy/client.py
@@ -36,13 +36,13 @@ class JsonClient:
     """
 
     def __init__(
-        self, url: str, auth: Auth = None, verify_ssl: bool = True
+        self, url: str, auth: Auth = None, verify: bool = True
     ) -> None:
         self.url = url
         self.session = requests.Session()
         if auth is not None:
             self.session.auth = auth
-        self.session.verify = verify_ssl
+        self.session.verify = verify
 
     def close(self) -> None:
         self.session.close()
@@ -68,14 +68,14 @@ class LivyClient:
 
     :param url: The URL of the Livy server.
     :param auth: A requests-compatible auth object to use when making requests.
-    :param verify_ssl: Whether to verify the server's TLS certificate. Defaults
-        to ``True``.
+    :param verify: Whether to verify the server's TLS certificate. Defaults to
+        ``True``.
     """
 
     def __init__(
-        self, url: str, auth: Auth = None, verify_ssl: bool = True
+        self, url: str, auth: Auth = None, verify: bool = True
     ) -> None:
-        self._client = JsonClient(url, auth, verify_ssl)
+        self._client = JsonClient(url, auth, verify)
         self._server_version_cache: Optional[Version] = None
 
     def close(self) -> None:

--- a/livy/client.py
+++ b/livy/client.py
@@ -35,10 +35,12 @@ class JsonClient:
     HTTP code is received.
     """
 
-    def __init__(self, url: str, auth: Auth = None) -> None:
+    def __init__(
+        self, url: str, auth: Auth = None, verify: bool = False
+    ) -> None:
         self.url = url
         self.session = requests.Session()
-        self.session.verify = False
+        self.session.verify_ssl = verify
         if auth is not None:
             self.session.auth = auth
 
@@ -56,12 +58,15 @@ class JsonClient:
 
     def _request(self, method: str, endpoint: str, data: dict = None) -> dict:
         url = self.url.rstrip("/") + endpoint
-        response = self.session.request(method, url,
-                                        json=data,
-                                        auth=self.session.auth,
-                                        headers=self.session.headers,
-                                        params=self.session.params,
-                                        verify=self.session.verify)
+        response = self.session.request(
+            method,
+            url,
+            json=data,
+            auth=self.session.auth,
+            headers=self.session.headers,
+            params=self.session.params,
+            verify=self.session.verify_ssl,
+        )
         response.raise_for_status()
         return response.json()
 
@@ -71,10 +76,15 @@ class LivyClient:
 
     :param url: The URL of the Livy server.
     :param auth: A requests-compatible auth object to use when making requests.
+    :param verify_ssl: This option is used when SSL authentication is used, and the existence of the certificate
+        must be verified or certified with some certification authority.
+        Defaults to ``False``.
     """
 
-    def __init__(self, url: str, auth: Auth = None) -> None:
-        self._client = JsonClient(url, auth)
+    def __init__(
+        self, url: str, auth: Auth = None, verify_ssl: bool = False
+    ) -> None:
+        self._client = JsonClient(url, auth, verify_ssl)
         self._server_version_cache: Optional[Version] = None
 
     def close(self) -> None:

--- a/livy/client.py
+++ b/livy/client.py
@@ -36,7 +36,7 @@ class JsonClient:
     """
 
     def __init__(
-        self, url: str, auth: Auth = None, verify: bool = False
+        self, url: str, auth: Auth = None, verify: bool = True
     ) -> None:
         self.url = url
         self.session = requests.Session()
@@ -83,7 +83,7 @@ class LivyClient:
     """
 
     def __init__(
-        self, url: str, auth: Auth = None, verify_ssl: bool = False
+        self, url: str, auth: Auth = None, verify_ssl: bool = True
     ) -> None:
         self._client = JsonClient(url, auth, verify_ssl)
         self._server_version_cache: Optional[Version] = None

--- a/livy/client.py
+++ b/livy/client.py
@@ -68,10 +68,8 @@ class LivyClient:
 
     :param url: The URL of the Livy server.
     :param auth: A requests-compatible auth object to use when making requests.
-    :param verify_ssl: This option is used when SSL authentication is used,
-        and the existence of the certificate
-        must be verified or certified with some certification authority.
-        Defaults to ``False``.
+    :param verify_ssl: Whether to verify the server's TLS certificate. Defaults
+        to ``True``.
     """
 
     def __init__(

--- a/livy/client.py
+++ b/livy/client.py
@@ -40,7 +40,7 @@ class JsonClient:
     ) -> None:
         self.url = url
         self.session = requests.Session()
-        self.session.verify_ssl = verify
+        self.session.verify = verify
         if auth is not None:
             self.session.auth = auth
 
@@ -65,7 +65,7 @@ class JsonClient:
             auth=self.session.auth,
             headers=self.session.headers,
             params=self.session.params,
-            verify=self.session.verify_ssl,
+            verify=self.session.verify,
         )
         response.raise_for_status()
         return response.json()

--- a/livy/client.py
+++ b/livy/client.py
@@ -36,13 +36,13 @@ class JsonClient:
     """
 
     def __init__(
-        self, url: str, auth: Auth = None, verify: bool = True
+        self, url: str, auth: Auth = None, verify_ssl: bool = True
     ) -> None:
         self.url = url
         self.session = requests.Session()
-        self.session.verify = verify
         if auth is not None:
             self.session.auth = auth
+        self.session.verify = verify_ssl
 
     def close(self) -> None:
         self.session.close()

--- a/livy/client.py
+++ b/livy/client.py
@@ -7,6 +7,7 @@ from livy.models import Version, Session, SessionKind, Statement, StatementKind
 
 
 Auth = Union[requests.auth.AuthBase, Tuple[str, str]]
+Verify = Union[bool, str]
 
 
 LOGGER = logging.getLogger(__name__)
@@ -36,7 +37,7 @@ class JsonClient:
     """
 
     def __init__(
-        self, url: str, auth: Auth = None, verify: bool = True
+        self, url: str, auth: Auth = None, verify: Verify = True
     ) -> None:
         self.url = url
         self.session = requests.Session()
@@ -68,12 +69,13 @@ class LivyClient:
 
     :param url: The URL of the Livy server.
     :param auth: A requests-compatible auth object to use when making requests.
-    :param verify: Whether to verify the server's TLS certificate. Defaults to
-        ``True``.
+    :param verify: Either a boolean, in which case it controls whether we
+        verify the server’s TLS certificate, or a string, in which case it must
+        be a path to a CA bundle to use. Defaults to ``True``.
     """
 
     def __init__(
-        self, url: str, auth: Auth = None, verify: bool = True
+        self, url: str, auth: Auth = None, verify: Verify = True
     ) -> None:
         self._client = JsonClient(url, auth, verify)
         self._server_version_cache: Optional[Version] = None

--- a/livy/session.py
+++ b/livy/session.py
@@ -141,7 +141,7 @@ class LivySession:
         check: bool = True,
         verify_ssl: bool = True,
     ) -> None:
-        self.client = LivyClient(url, auth, verify_ssl = verify_ssl)
+        self.client = LivyClient(url, auth, verify_ssl=verify_ssl)
         self.kind = kind
         self.proxy_user = proxy_user
         self.jars = jars

--- a/livy/session.py
+++ b/livy/session.py
@@ -93,6 +93,9 @@ class LivySession:
     information on Spark configuration properties.
 
     :param url: The URL of the Livy server.
+    :param verify: Either a boolean, in which case it controls whether we
+        verify the server’s TLS certificate, or a string, in which case it must
+        be a path to a CA bundle to use. Defaults to ``True``.
     :param kind: The kind of session to create.
     :param proxy_user: User to impersonate when starting the session.
     :param jars: URLs of jars to be used in this session.
@@ -113,15 +116,13 @@ class LivySession:
         to ``True``.
     :param check: Whether to raise an exception when a statement in the remote
         session fails. Defaults to ``True``.
-    :param verify: Either a boolean, in which case it controls whether we
-        verify the server’s TLS certificate, or a string, in which case it must
-        be a path to a CA bundle to use. Defaults to ``True``.
     """
 
     def __init__(
         self,
         url: str,
         auth: Auth = None,
+        verify: Verify = True,
         kind: SessionKind = SessionKind.PYSPARK,
         proxy_user: str = None,
         jars: List[str] = None,
@@ -138,7 +139,6 @@ class LivySession:
         spark_conf: Dict[str, Any] = None,
         echo: bool = True,
         check: bool = True,
-        verify: Verify = True,
     ) -> None:
         self.client = LivyClient(url, auth, verify=verify)
         self.kind = kind

--- a/livy/session.py
+++ b/livy/session.py
@@ -113,6 +113,9 @@ class LivySession:
         to ``True``.
     :param check: Whether to raise an exception when a statement in the remote
         session fails. Defaults to ``True``.
+    :param verify_ssl: This option is used when SSL authentication is used, and the existence of the certificate
+        must be verified or certified with some certification authority.
+        Defaults to ``False``.
     """
 
     def __init__(
@@ -135,7 +138,7 @@ class LivySession:
         spark_conf: Dict[str, Any] = None,
         echo: bool = True,
         check: bool = True,
-        verify: bool = False
+        verify_ssl: bool = False,
     ) -> None:
         self.client = LivyClient(url, auth)
         self.kind = kind
@@ -154,7 +157,7 @@ class LivySession:
         self.spark_conf = spark_conf
         self.echo = echo
         self.check = check
-        self.verify = verify
+        self.verify_ssl = verify_ssl
         self.session_id: Optional[int] = None
 
     def __enter__(self) -> "LivySession":

--- a/livy/session.py
+++ b/livy/session.py
@@ -135,6 +135,7 @@ class LivySession:
         spark_conf: Dict[str, Any] = None,
         echo: bool = True,
         check: bool = True,
+        verify: bool = False
     ) -> None:
         self.client = LivyClient(url, auth)
         self.kind = kind
@@ -153,6 +154,7 @@ class LivySession:
         self.spark_conf = spark_conf
         self.echo = echo
         self.check = check
+        self.verify = verify
         self.session_id: Optional[int] = None
 
     def __enter__(self) -> "LivySession":

--- a/livy/session.py
+++ b/livy/session.py
@@ -113,7 +113,8 @@ class LivySession:
         to ``True``.
     :param check: Whether to raise an exception when a statement in the remote
         session fails. Defaults to ``True``.
-    :param verify_ssl: This option is used when SSL authentication is used, and the existence of the certificate
+    :param verify_ssl: This option is used when SSL authentication is used,
+        and the existence of the certificate
         must be verified or certified with some certification authority.
         Defaults to ``False``.
     """

--- a/livy/session.py
+++ b/livy/session.py
@@ -116,7 +116,7 @@ class LivySession:
     :param verify_ssl: This option is used when SSL authentication is used,
         and the existence of the certificate
         must be verified or certified with some certification authority.
-        Defaults to ``False``.
+        Defaults to ``True``.
     """
 
     def __init__(
@@ -139,9 +139,9 @@ class LivySession:
         spark_conf: Dict[str, Any] = None,
         echo: bool = True,
         check: bool = True,
-        verify_ssl: bool = False,
+        verify_ssl: bool = True,
     ) -> None:
-        self.client = LivyClient(url, auth)
+        self.client = LivyClient(url, auth, verify_ssl = verify_ssl)
         self.kind = kind
         self.proxy_user = proxy_user
         self.jars = jars

--- a/livy/session.py
+++ b/livy/session.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List, Iterable, Iterator, Optional
 
 import pandas
 
-from livy.client import LivyClient, Auth
+from livy.client import LivyClient, Auth, Verify
 from livy.models import SessionKind, SessionState, StatementState, Output
 
 
@@ -113,10 +113,9 @@ class LivySession:
         to ``True``.
     :param check: Whether to raise an exception when a statement in the remote
         session fails. Defaults to ``True``.
-    :param verify: This option is used when SSL authentication is used,
-        and the existence of the certificate
-        must be verified or certified with some certification authority.
-        Defaults to ``True``.
+    :param verify: Either a boolean, in which case it controls whether we
+        verify the server’s TLS certificate, or a string, in which case it must
+        be a path to a CA bundle to use. Defaults to ``True``.
     """
 
     def __init__(
@@ -139,7 +138,7 @@ class LivySession:
         spark_conf: Dict[str, Any] = None,
         echo: bool = True,
         check: bool = True,
-        verify: bool = True,
+        verify: Verify = True,
     ) -> None:
         self.client = LivyClient(url, auth, verify=verify)
         self.kind = kind

--- a/livy/session.py
+++ b/livy/session.py
@@ -93,6 +93,7 @@ class LivySession:
     information on Spark configuration properties.
 
     :param url: The URL of the Livy server.
+    :param auth: A requests-compatible auth object to use when making requests.
     :param verify: Either a boolean, in which case it controls whether we
         verify the server’s TLS certificate, or a string, in which case it must
         be a path to a CA bundle to use. Defaults to ``True``.

--- a/livy/session.py
+++ b/livy/session.py
@@ -158,7 +158,6 @@ class LivySession:
         self.spark_conf = spark_conf
         self.echo = echo
         self.check = check
-        self.verify = verify
         self.session_id: Optional[int] = None
 
     def __enter__(self) -> "LivySession":

--- a/livy/session.py
+++ b/livy/session.py
@@ -113,7 +113,7 @@ class LivySession:
         to ``True``.
     :param check: Whether to raise an exception when a statement in the remote
         session fails. Defaults to ``True``.
-    :param verify_ssl: This option is used when SSL authentication is used,
+    :param verify: This option is used when SSL authentication is used,
         and the existence of the certificate
         must be verified or certified with some certification authority.
         Defaults to ``True``.
@@ -139,9 +139,9 @@ class LivySession:
         spark_conf: Dict[str, Any] = None,
         echo: bool = True,
         check: bool = True,
-        verify_ssl: bool = True,
+        verify: bool = True,
     ) -> None:
-        self.client = LivyClient(url, auth, verify_ssl=verify_ssl)
+        self.client = LivyClient(url, auth, verify=verify)
         self.kind = kind
         self.proxy_user = proxy_user
         self.jars = jars
@@ -158,7 +158,7 @@ class LivySession:
         self.spark_conf = spark_conf
         self.echo = echo
         self.check = check
-        self.verify_ssl = verify_ssl
+        self.verify = verify
         self.session_id: Optional[int] = None
 
     def __enter__(self) -> "LivySession":

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -24,7 +24,7 @@ MOCK_QUEUE = "mock-queue"
 MOCK_NAME = "mock-session-name"
 
 
-@pytest.mark.parametrize("verify", [True, False])
+@pytest.mark.parametrize("verify", [True, False, "my/ca/bundle"])
 def test_verify(requests_mock, mocker, verify):
     requests_mock.get(
         "http://example.com/sessions", json={"sessions": []}

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,3 +1,5 @@
+import pytest
+
 from livy.client import LivyClient
 from livy.models import Session, SessionKind, Statement, StatementKind
 
@@ -20,6 +22,20 @@ MOCK_NUM_EXECUTORS = 6
 MOCK_ARCHIVES = ["mock1.tar.gz", "mock2.tar.gz"]
 MOCK_QUEUE = "mock-queue"
 MOCK_NAME = "mock-session-name"
+
+
+@pytest.mark.parametrize("verify", [True, False])
+def test_verify(requests_mock, mocker, verify):
+    requests_mock.get(
+        "http://example.com/sessions", json={"sessions": []}
+    )
+    mocker.patch.object(Session, "from_json")
+
+    client = LivyClient("http://example.com", verify=verify)
+    client.list_sessions()
+
+    [request] = requests_mock.request_history
+    assert request.verify is verify
 
 
 def test_list_sessions(requests_mock, mocker):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -26,9 +26,7 @@ MOCK_NAME = "mock-session-name"
 
 @pytest.mark.parametrize("verify", [True, False, "my/ca/bundle"])
 def test_verify(requests_mock, mocker, verify):
-    requests_mock.get(
-        "http://example.com/sessions", json={"sessions": []}
-    )
+    requests_mock.get("http://example.com/sessions", json={"sessions": []})
     mocker.patch.object(Session, "from_json")
 
     client = LivyClient("http://example.com", verify=verify)


### PR DESCRIPTION
the "verify" option was not available in the pylivy code
I have modified session.py and client.py to accept this option

This fix works for my application

Thanks for an evaluation of my changes

Chris Arnault

chris.arnault.1@gmail.com

