### PR TITLE
Fix typo in index.rst

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -48,7 +48,7 @@ Authenticate requests sent to Livy by passing `any requests Auth object
         session.run("filtered = df.filter(df.name == 'Bob')")
         local_df = session.read('filtered')
 
-API Documenation
+API Documentation
 ----------------
 
 .. toctree::

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -49,7 +49,7 @@ Authenticate requests sent to Livy by passing `any requests Auth object
         local_df = session.read('filtered')
 
 API Documentation
-----------------
+-----------------
 
 .. toctree::
     :maxdepth: 2


### PR DESCRIPTION
'Documenation' -> 'Documentation'