### PR TITLE
Revised interface

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -33,7 +33,7 @@ The :class:`~livy.session.LivySession` class is the main interface provided by
 
     LIVY_URL = 'http://spark.example.com:8998'
 
-    with LivySession(LIVY_URL) as session:
+    with LivySession.create(LIVY_URL) as session:
         # Run some code on the remote cluster
         session.run("filtered = df.filter(df.name == 'Bob')")
         # Retrieve the result
@@ -47,7 +47,7 @@ Authenticate requests sent to Livy by passing `any requests Auth object
 
     auth = HTTPBasicAuth('username', 'password')
 
-    with LivySession(LIVY_URL, auth) as session:
+    with LivySession.create(LIVY_URL, auth) as session:
         session.run("filtered = df.filter(df.name == 'Bob')")
         local_df = session.read('filtered')
 
@@ -58,7 +58,7 @@ Similarly, batch sessions in Livy can be created and managed with the
 
     LIVY_URL = 'http://spark.example.com:8998'
 
-    batch = LivyBatch(
+    batch = LivyBatch.create(
         integration_url,
         file=(
             "https://repo.typesafe.com/typesafe/maven-releases/org/"

--- a/livy/batch.py
+++ b/livy/batch.py
@@ -1,7 +1,7 @@
 import time
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List
 
-from livy.client import LivyClient, Auth
+from livy.client import LivyClient, Auth, Verify
 from livy.models import SessionState, SESSION_STATE_FINISHED
 from livy.utils import polling_intervals
 
@@ -9,52 +9,31 @@ from livy.utils import polling_intervals
 class LivyBatch:
     """Manages a remote Livy batch and high-level interactions with it.
 
-    The py_files, files, jars and archives arguments are lists of URLs, e.g.
-    ["s3://bucket/object", "hdfs://path/to/file", ...] and must be reachable by
-    the Spark driver process.  If the provided URL has no scheme, it's
-    considered to be relative to the default file system configured in the Livy
-    server.
-
-    URLs in the py_files argument are copied to a temporary staging area and
-    inserted into Python's sys.path ahead of the standard library paths. This
-    allows you to import .py, .zip and .egg files in Python.
-
-    URLs for jars, py_files, files and archives arguments are all copied to the
-    same working directory on the Spark cluster.
-
-    The driver_memory and executor_memory arguments have the same format as JVM
-    memory strings with a size unit suffix ("k", "m", "g" or "t") (e.g. 512m,
-    2g).
-
-    See https://spark.apache.org/docs/latest/configuration.html for more
-    information on Spark configuration properties.
-
     :param url: The URL of the Livy server.
-    :param file: File containing the application to execute.
+    :param batch_id: The ID of the Livy batch.
     :param auth: A requests-compatible auth object to use when making requests.
-    :param class_name: Application Java/Spark main class.
-    :param proxy_user: User to impersonate when starting the session.
-    :param jars: URLs of jars to be used in this session.
-    :param py_files: URLs of Python files to be used in this session.
-    :param files: URLs of files to be used in this session.
-    :param driver_memory: Amount of memory to use for the driver process (e.g.
-        '512m').
-    :param driver_cores: Number of cores to use for the driver process.
-    :param executor_memory: Amount of memory to use per executor process (e.g.
-        '512m').
-    :param executor_cores: Number of cores to use for each executor.
-    :param num_executors: Number of executors to launch for this session.
-    :param archives: URLs of archives to be used in this session.
-    :param queue: The name of the YARN queue to which submitted.
-    :param name: The name of this session.
-    :param spark_conf: Spark configuration properties.
+    :param verify: Either a boolean, in which case it controls whether we
+        verify the server’s TLS certificate, or a string, in which case it must
+        be a path to a CA bundle to use. Defaults to ``True``.
     """
 
     def __init__(
         self,
         url: str,
+        batch_id: int,
+        auth: Auth = None,
+        verify: Verify = True,
+    ) -> None:
+        self.client = LivyClient(url, auth, verify=verify)
+        self.batch_id = batch_id
+
+    @classmethod
+    def create(
+        cls,
+        url: str,
         file: str,
         auth: Auth = None,
+        verify: Verify = True,
         class_name: str = None,
         args: List[str] = None,
         proxy_user: str = None,
@@ -70,50 +49,74 @@ class LivyBatch:
         queue: str = None,
         name: str = None,
         spark_conf: Dict[str, Any] = None,
-    ) -> None:
-        self.client = LivyClient(url, auth)
-        self.file = file
-        self.class_name = class_name
-        self.args = args
-        self.proxy_user = proxy_user
-        self.jars = jars
-        self.py_files = py_files
-        self.files = files
-        self.driver_memory = driver_memory
-        self.driver_cores = driver_cores
-        self.executor_memory = executor_memory
-        self.executor_cores = executor_cores
-        self.num_executors = num_executors
-        self.archives = archives
-        self.queue = queue
-        self.name = name
-        self.spark_conf = spark_conf
-        self.batch_id: Optional[int] = None
+    ) -> "LivyBatch":
+        """Create a new Livy batch session.
 
-    def start(self) -> None:
-        """Create the batch session.
+        The py_files, files, jars and archives arguments are lists of URLs,
+        e.g. ["s3://bucket/object", "hdfs://path/to/file", ...] and must be
+        reachable by the Spark driver process. If the provided URL has no
+        scheme, it's considered to be relative to the default file system
+        configured in the Livy server.
 
-        Unlike LivySession, this does not wait for the session to be ready.
+        URLs in the py_files argument are copied to a temporary staging area
+        and inserted into Python's sys.path ahead of the standard library
+        paths. This allows you to import .py, .zip and .egg files in Python.
+
+        URLs for jars, py_files, files and archives arguments are all copied to
+        the same working directory on the Spark cluster.
+
+        The driver_memory and executor_memory arguments have the same format as
+        JVM memory strings with a size unit suffix ("k", "m", "g" or "t") (e.g.
+        512m, 2g).
+
+        See https://spark.apache.org/docs/latest/configuration.html for more
+        information on Spark configuration properties.
+
+        :param url: The URL of the Livy server.
+        :param file: File containing the application to execute.
+        :param auth: A requests-compatible auth object to use when making
+            requests.
+        :param verify: Either a boolean, in which case it controls whether we
+            verify the server’s TLS certificate, or a string, in which case it
+            must be a path to a CA bundle to use. Defaults to ``True``.
+        :param class_name: Application Java/Spark main class.
+        :param proxy_user: User to impersonate when starting the session.
+        :param jars: URLs of jars to be used in this session.
+        :param py_files: URLs of Python files to be used in this session.
+        :param files: URLs of files to be used in this session.
+        :param driver_memory: Amount of memory to use for the driver process
+            (e.g. '512m').
+        :param driver_cores: Number of cores to use for the driver process.
+        :param executor_memory: Amount of memory to use per executor process
+            (e.g. '512m').
+        :param executor_cores: Number of cores to use for each executor.
+        :param num_executors: Number of executors to launch for this session.
+        :param archives: URLs of archives to be used in this session.
+        :param queue: The name of the YARN queue to which submitted.
+        :param name: The name of this session.
+        :param spark_conf: Spark configuration properties.
         """
-        batch = self.client.create_batch(
-            self.file,
-            self.class_name,
-            self.args,
-            self.proxy_user,
-            self.jars,
-            self.py_files,
-            self.files,
-            self.driver_memory,
-            self.driver_cores,
-            self.executor_memory,
-            self.executor_cores,
-            self.num_executors,
-            self.archives,
-            self.queue,
-            self.name,
-            self.spark_conf,
+        client = LivyClient(url, auth, verify=verify)
+        batch = client.create_batch(
+            file,
+            class_name,
+            args,
+            proxy_user,
+            jars,
+            py_files,
+            files,
+            driver_memory,
+            driver_cores,
+            executor_memory,
+            executor_cores,
+            num_executors,
+            archives,
+            queue,
+            name,
+            spark_conf,
         )
-        self.batch_id = batch.batch_id
+        client.close()
+        return cls(url, batch.batch_id, auth, verify)
 
     def wait(self) -> SessionState:
         """Wait for the batch session to finish."""
@@ -131,8 +134,6 @@ class LivyBatch:
     @property
     def state(self) -> SessionState:
         """The state of the managed Spark batch."""
-        if self.batch_id is None:
-            raise ValueError("batch session not yet started")
         batch = self.client.get_batch(self.batch_id)
         if batch is None:
             raise ValueError(
@@ -146,8 +147,6 @@ class LivyBatch:
         :param from_: The line number to start getting logs from.
         :param size: The number of lines of logs to get.
         """
-        if self.batch_id is None:
-            raise ValueError("batch session not yet started")
         log = self.client.get_batch_log(self.batch_id, from_, size)
         if log is None:
             raise ValueError(
@@ -157,6 +156,5 @@ class LivyBatch:
 
     def kill(self) -> None:
         """Kill the managed Spark batch session."""
-        if self.batch_id is not None:
-            self.client.delete_batch(self.batch_id)
+        self.client.delete_batch(self.batch_id)
         self.client.close()

--- a/livy/client.py
+++ b/livy/client.py
@@ -332,7 +332,7 @@ class LivyClient:
         :param spark_conf: Spark configuration properties.
         """
 
-        batch_session_params = {"file": file}
+        batch_session_params: Dict[str, Any] = {"file": file}
         if class_name is not None:
             batch_session_params["className"] = class_name
         if args is not None:

--- a/livy/client.py
+++ b/livy/client.py
@@ -185,33 +185,23 @@ class LivyClient:
                 f"this version (should be one of {valid_kinds})"
             )
 
-        body: Dict[str, Any] = {"kind": kind.value}
-        if proxy_user is not None:
-            body["proxyUser"] = proxy_user
-        if jars is not None:
-            body["jars"] = jars
-        if py_files is not None:
-            body["pyFiles"] = py_files
-        if files is not None:
-            body["files"] = files
-        if driver_memory is not None:
-            body["driverMemory"] = driver_memory
-        if driver_cores is not None:
-            body["driverCores"] = driver_cores
-        if executor_memory is not None:
-            body["executorMemory"] = executor_memory
-        if executor_cores is not None:
-            body["executorCores"] = executor_cores
-        if num_executors is not None:
-            body["numExecutors"] = num_executors
-        if archives is not None:
-            body["archives"] = archives
-        if queue is not None:
-            body["queue"] = queue
-        if name is not None:
-            body["name"] = name
-        if spark_conf is not None:
-            body["conf"] = spark_conf
+        interactive_session_params = {"kind": kind.value}
+        common_params = _new_session_body(
+            proxy_user,
+            jars,
+            py_files,
+            files,
+            driver_memory,
+            driver_cores,
+            executor_memory,
+            executor_cores,
+            num_executors,
+            archives,
+            queue,
+            name,
+            spark_conf,
+        )
+        body = {**interactive_session_params, **common_params}
 
         data = self._client.post("/sessions", data=body)
         return Session.from_json(data)
@@ -342,37 +332,27 @@ class LivyClient:
         :param spark_conf: Spark configuration properties.
         """
 
-        body: Dict[str, Any] = {"file": file}
+        batch_session_params = {"file": file}
         if class_name is not None:
-            body["className"] = class_name
+            batch_session_params["className"] = class_name
         if args is not None:
-            body["args"] = args
-        if proxy_user is not None:
-            body["proxyUser"] = proxy_user
-        if jars is not None:
-            body["jars"] = jars
-        if py_files is not None:
-            body["pyFiles"] = py_files
-        if files is not None:
-            body["files"] = files
-        if driver_memory is not None:
-            body["driverMemory"] = driver_memory
-        if driver_cores is not None:
-            body["driverCores"] = driver_cores
-        if executor_memory is not None:
-            body["executorMemory"] = executor_memory
-        if executor_cores is not None:
-            body["executorCores"] = executor_cores
-        if num_executors is not None:
-            body["numExecutors"] = num_executors
-        if archives is not None:
-            body["archives"] = archives
-        if queue is not None:
-            body["queue"] = queue
-        if name is not None:
-            body["name"] = name
-        if spark_conf is not None:
-            body["conf"] = spark_conf
+            batch_session_params["args"] = args
+        common_params = _new_session_body(
+            proxy_user,
+            jars,
+            py_files,
+            files,
+            driver_memory,
+            driver_cores,
+            executor_memory,
+            executor_cores,
+            num_executors,
+            archives,
+            queue,
+            name,
+            spark_conf,
+        )
+        body = {**batch_session_params, **common_params}
 
         data = self._client.post("/batches", data=body)
         return Batch.from_json(data)
@@ -425,3 +405,48 @@ class LivyClient:
         """List all the active batches in Livy."""
         response = self._client.get("/batches")
         return [Batch.from_json(data) for data in response["sessions"]]
+
+
+def _new_session_body(
+    proxy_user: Optional[str],
+    jars: Optional[List[str]],
+    py_files: Optional[List[str]],
+    files: Optional[List[str]],
+    driver_memory: Optional[str],
+    driver_cores: Optional[int],
+    executor_memory: Optional[str],
+    executor_cores: Optional[int],
+    num_executors: Optional[int],
+    archives: Optional[List[str]],
+    queue: Optional[str],
+    name: Optional[str],
+    spark_conf: Optional[Dict[str, Any]],
+) -> Dict[str, Any]:
+    body: Dict[str, Any] = {}
+    if proxy_user is not None:
+        body["proxyUser"] = proxy_user
+    if jars is not None:
+        body["jars"] = jars
+    if py_files is not None:
+        body["pyFiles"] = py_files
+    if files is not None:
+        body["files"] = files
+    if driver_memory is not None:
+        body["driverMemory"] = driver_memory
+    if driver_cores is not None:
+        body["driverCores"] = driver_cores
+    if executor_memory is not None:
+        body["executorMemory"] = executor_memory
+    if executor_cores is not None:
+        body["executorCores"] = executor_cores
+    if num_executors is not None:
+        body["numExecutors"] = num_executors
+    if archives is not None:
+        body["archives"] = archives
+    if queue is not None:
+        body["queue"] = queue
+    if name is not None:
+        body["name"] = name
+    if spark_conf is not None:
+        body["conf"] = spark_conf
+    return body

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -100,7 +100,7 @@ def test_session(integration_url, capsys, session_kind, params):
 
     assert livy_available(integration_url)
 
-    with LivySession(integration_url, kind=session_kind) as session:
+    with LivySession.create(integration_url, kind=session_kind) as session:
 
         assert session.state == SessionState.IDLE
 
@@ -132,7 +132,7 @@ def test_sql_session(integration_url):
 
     assert livy_available(integration_url)
 
-    with LivySession(integration_url, kind=SessionKind.SQL) as session:
+    with LivySession.create(integration_url, kind=SessionKind.SQL) as session:
 
         assert session.state == SessionState.IDLE
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -154,7 +154,7 @@ def test_batch_job(integration_url):
 
     assert livy_available(integration_url)
 
-    batch = LivyBatch(
+    batch = LivyBatch.create(
         integration_url,
         file=(
             "https://repo.typesafe.com/typesafe/maven-releases/org/apache/"
@@ -163,9 +163,6 @@ def test_batch_job(integration_url):
         ),
         class_name="org.apache.spark.examples.SparkPi",
     )
-    assert batch.batch_id is None
-
-    batch.start()
 
     assert batch.state == SessionState.RUNNING
 


### PR DESCRIPTION
This PR proposes a new interface for the `LivySession` and `LivyBatch` classes.

Previously, all options used to create either of the above session types needed to be passed to the constructor. All options were stored as attributes in those classes, and then were used when `.start()` was called and the relevant request to create the session on the server was sent.

This interface was ok, but:

1. prevented using these classes to interact with existing sessions
2. required keeping ~20 attributes that only ever got used once
3. required various methods to handle the case when the session had not yet been created (and so no session ID was known)

This PR resolves those issues by taking session creation out of the class and into a factory function (it is a classmethod on the class but only for API conciseness). When using these factory functions, the session is created, and a session is created with the resulting ID. This session object can then be used the same as before:

```python
with LivySession.create(LIVY_URL) as session:
    session.run("filtered = df.filter(df.name == 'Bob')")
```

Alternatively, users can connect to running sessions by constructing the session object directly with the relevant ID:

```python
with LivySession(LIVY_URL, session_id=3) as session:
    session.run("filtered = df.filter(df.name == 'Bob')")
```

An alternative to this was proposed in #67 (thanks @rondiplomatico!), however I'm not keen on that solution as it does not address all of the issues identified above.

Thoughts from users of the library on this change are encouraged (even if neutral) as I don't want to push API breaking changes willy nilly.