### PR TITLE
add Heartbeat Timeout param in session creation

### DIFF
--- a/livy/client.py
+++ b/livy/client.py
@@ -479,7 +479,8 @@ def _new_session_body(
         body["name"] = name
     if spark_conf is not None:
         body["conf"] = spark_conf
-    # heartbeat_timeout is only supported for interactive sessions, not batch sessions
+    # heartbeat_timeout is only supported for interactive sessions
+    # not for batch sessions
     if heartbeat_timeout is not None:
         body["heartbeatTimeoutInSecond"] = heartbeat_timeout
     return body

--- a/livy/client.py
+++ b/livy/client.py
@@ -380,7 +380,6 @@ class LivyClient:
             queue,
             name,
             spark_conf,
-            heartbeat_timeout=None,
         )
         body = {**batch_session_params, **common_params}
 
@@ -451,7 +450,7 @@ def _new_session_body(
     queue: Optional[str],
     name: Optional[str],
     spark_conf: Optional[Dict[str, Any]],
-    heartbeat_timeout: Optional[int],
+    heartbeat_timeout: Optional[int] = None,
 ) -> Dict[str, Any]:
     body: Dict[str, Any] = {}
     if proxy_user is not None:
@@ -480,6 +479,7 @@ def _new_session_body(
         body["name"] = name
     if spark_conf is not None:
         body["conf"] = spark_conf
+    # heartbeat_timeout is only supported for interactive sessions, not batch sessions
     if heartbeat_timeout is not None:
         body["heartbeatTimeoutInSecond"] = heartbeat_timeout
     return body

--- a/livy/client.py
+++ b/livy/client.py
@@ -159,7 +159,7 @@ class LivyClient:
         queue: str = None,
         name: str = None,
         spark_conf: Dict[str, Any] = None,
-        heartbeat_timeout: Optional[int] = None,
+        heartbeat_timeout: int = None,
     ) -> Session:
         """Create a new session in Livy.
 

--- a/livy/client.py
+++ b/livy/client.py
@@ -214,6 +214,10 @@ class LivyClient:
             )
 
         interactive_session_params = {"kind": kind.value}
+        if heartbeat_timeout is not None:
+            interactive_session_params[
+                "heartbeatTimeoutInSecond"
+            ] = heartbeat_timeout
         common_params = _new_session_body(
             proxy_user,
             jars,
@@ -228,7 +232,6 @@ class LivyClient:
             queue,
             name,
             spark_conf,
-            heartbeat_timeout,
         )
         body = {**interactive_session_params, **common_params}
 
@@ -450,7 +453,6 @@ def _new_session_body(
     queue: Optional[str],
     name: Optional[str],
     spark_conf: Optional[Dict[str, Any]],
-    heartbeat_timeout: Optional[int] = None,
 ) -> Dict[str, Any]:
     body: Dict[str, Any] = {}
     if proxy_user is not None:
@@ -479,8 +481,4 @@ def _new_session_body(
         body["name"] = name
     if spark_conf is not None:
         body["conf"] = spark_conf
-    # heartbeat_timeout is only supported for interactive sessions
-    # not for batch sessions
-    if heartbeat_timeout is not None:
-        body["heartbeatTimeoutInSecond"] = heartbeat_timeout
     return body

--- a/livy/client.py
+++ b/livy/client.py
@@ -159,6 +159,7 @@ class LivyClient:
         queue: str = None,
         name: str = None,
         spark_conf: Dict[str, Any] = None,
+        heartbeat_timeout: Optional[int] = None,
     ) -> Session:
         """Create a new session in Livy.
 
@@ -198,6 +199,8 @@ class LivyClient:
         :param queue: The name of the YARN queue to which submitted.
         :param name: The name of this session.
         :param spark_conf: Spark configuration properties.
+        :param heartbeat_timeout: Optional Timeout in seconds to which session
+            be automatically orphaned if no heartbeat is received.
         """
         if self.legacy_server():
             valid_kinds = VALID_LEGACY_SESSION_KINDS
@@ -225,6 +228,7 @@ class LivyClient:
             queue,
             name,
             spark_conf,
+            heartbeat_timeout,
         )
         body = {**interactive_session_params, **common_params}
 
@@ -376,6 +380,7 @@ class LivyClient:
             queue,
             name,
             spark_conf,
+            heartbeat_timeout=None,
         )
         body = {**batch_session_params, **common_params}
 
@@ -446,6 +451,7 @@ def _new_session_body(
     queue: Optional[str],
     name: Optional[str],
     spark_conf: Optional[Dict[str, Any]],
+    heartbeat_timeout: Optional[int],
 ) -> Dict[str, Any]:
     body: Dict[str, Any] = {}
     if proxy_user is not None:
@@ -474,4 +480,6 @@ def _new_session_body(
         body["name"] = name
     if spark_conf is not None:
         body["conf"] = spark_conf
+    if heartbeat_timeout is not None:
+        body["heartbeatTimeoutInSecond"] = heartbeat_timeout
     return body

--- a/livy/session.py
+++ b/livy/session.py
@@ -1,6 +1,6 @@
 import time
 import json
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List
 
 import requests
 import pandas
@@ -118,7 +118,7 @@ class LivySession:
         queue: str = None,
         name: str = None,
         spark_conf: Dict[str, Any] = None,
-        heartbeat_timeout: Optional[int] = None,
+        heartbeat_timeout: int = None,
         echo: bool = True,
         check: bool = True,
     ) -> "LivySession":

--- a/livy/session.py
+++ b/livy/session.py
@@ -1,6 +1,6 @@
 import time
 import json
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 import requests
 import pandas
@@ -118,6 +118,7 @@ class LivySession:
         queue: str = None,
         name: str = None,
         spark_conf: Dict[str, Any] = None,
+        heartbeat_timeout: Optional[int] = None,
         echo: bool = True,
         check: bool = True,
     ) -> "LivySession":
@@ -168,6 +169,8 @@ class LivySession:
         :param queue: The name of the YARN queue to which submitted.
         :param name: The name of this session.
         :param spark_conf: Spark configuration properties.
+        :param heartbeat_timeout: Optional Timeout in seconds to which session
+            be automatically orphaned if no heartbeat is received.
         :param echo: Whether to echo output printed in the remote session.
             Defaults to ``True``.
         :param check: Whether to raise an exception when a statement in the
@@ -189,6 +192,7 @@ class LivySession:
             queue,
             name,
             spark_conf,
+            heartbeat_timeout,
         )
         client.close()
         return cls(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -144,7 +144,7 @@ def test_create_session(requests_mock, mocker):
         "kind": "pyspark",
         "proxyUser": MOCK_PROXY_USER,
         "conf": MOCK_SPARK_CONF,
-        "heartbeatTimeoutInSecond": 500,
+        "heartbeatTimeoutInSecond": MOCK_HEARTBEAT_TIMEOUT,
         "jars": MOCK_JARS,
         "pyFiles": MOCK_PY_FILES,
         "files": MOCK_FILES,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -123,8 +123,6 @@ def test_create_session(requests_mock, mocker):
     session = client.create_session(
         SessionKind.PYSPARK,
         proxy_user=MOCK_PROXY_USER,
-        spark_conf=MOCK_SPARK_CONF,
-        heartbeat_timeout=MOCK_HEARTBEAT_TIMEOUT,
         jars=MOCK_JARS,
         py_files=MOCK_PY_FILES,
         files=MOCK_FILES,
@@ -136,6 +134,8 @@ def test_create_session(requests_mock, mocker):
         archives=MOCK_ARCHIVES,
         queue=MOCK_QUEUE,
         name=MOCK_NAME,
+        spark_conf=MOCK_SPARK_CONF,
+        heartbeat_timeout=MOCK_HEARTBEAT_TIMEOUT,
     )
 
     assert session == Session.from_json.return_value

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -18,6 +18,7 @@ MOCK_STATEMENT_ID = 12
 MOCK_CODE = "mock code"
 MOCK_PROXY_USER = "proxy-user"
 MOCK_SPARK_CONF = {"spark.master": "yarn", "spark.submit.deployMode": "client"}
+MOCK_HEARTBEAT_TIMEOUT = 500
 MOCK_JARS = ["mock1.jar", "mock2.jar"]
 MOCK_PY_FILES = ["mock1.py", "mock2.py"]
 MOCK_FILES = ["mockfile1.txt", "mockfile2.txt"]
@@ -123,6 +124,7 @@ def test_create_session(requests_mock, mocker):
         SessionKind.PYSPARK,
         proxy_user=MOCK_PROXY_USER,
         spark_conf=MOCK_SPARK_CONF,
+        heartbeat_timeout=MOCK_HEARTBEAT_TIMEOUT,
         jars=MOCK_JARS,
         py_files=MOCK_PY_FILES,
         files=MOCK_FILES,
@@ -142,6 +144,7 @@ def test_create_session(requests_mock, mocker):
         "kind": "pyspark",
         "proxyUser": MOCK_PROXY_USER,
         "conf": MOCK_SPARK_CONF,
+        "heartbeatTimeoutInSecond": 500,
         "jars": MOCK_JARS,
         "pyFiles": MOCK_PY_FILES,
         "files": MOCK_FILES,


### PR DESCRIPTION
The `livy` `POST /sessions` API has a useful parameter `heartbeatTimeoutInSecond` which sets a timeout which will automatically shut down the livy session if a heartbeat (eg. a session GET) is not received within the specified timeout.

This PR adds `heartbeat_timeout` to the client `create_session` method as well as the session Object. 

Happy to make any changes to this PR as per implementation / style / test preferences, etc. Let me know.

Thanks!