### PR TITLE
Actually pass parameters on client get requests

### DIFF
--- a/livy/client.py
+++ b/livy/client.py
@@ -67,7 +67,7 @@ class JsonClient:
             self.session.close()
 
     def get(self, endpoint: str = "", params: dict = None) -> dict:
-        return self._request("GET", endpoint)
+        return self._request("GET", endpoint, params=params)
 
     def post(self, endpoint: str, data: dict = None) -> dict:
         return self._request("POST", endpoint, data)


### PR DESCRIPTION
This PR fixes the client get requests that use parameters, such as `batch.log(from_=<line>)`, which is currently not working due to the query params not being passed in the request.