### PR TITLE
Add code attribute from Livy API to pylivy

### DIFF
--- a/livy/models.py
+++ b/livy/models.py
@@ -111,6 +111,7 @@ class Statement:
     session_id: int
     statement_id: int
     state: StatementState
+    code: str
     output: Optional[Output]
     progress: Optional[float]
 
@@ -125,6 +126,7 @@ class Statement:
             session_id,
             data["id"],
             StatementState(data["state"]),
+            data["code"],
             output,
             data.get("progress"),
         )

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -61,6 +61,7 @@ def test_statement_from_json_no_output():
     statement_json = {
         "id": 10,
         "state": "running",
+        "code": "dummy code",
         "output": None,
         "progress": 0.0,
     }
@@ -69,6 +70,7 @@ def test_statement_from_json_no_output():
         session_id,
         statement_id=10,
         state=StatementState.RUNNING,
+        code="dummy code",
         output=None,
         progress=0.0,
     )
@@ -84,6 +86,7 @@ def test_statement_from_json_with_output(mocker):
     statement_json = {
         "id": 10,
         "state": "running",
+        "code": "dummy code",
         "output": "dummy output",
         "progress": 0.5,
     }
@@ -92,6 +95,7 @@ def test_statement_from_json_with_output(mocker):
         session_id,
         statement_id=10,
         state=StatementState.RUNNING,
+        code="dummy code",
         output=Output.from_json.return_value,
         progress=0.5,
     )
@@ -108,6 +112,7 @@ def test_statement_from_json_no_progress(mocker):
     statement_json = {
         "id": 10,
         "state": "running",
+        "code": "dummy code",
         "output": "dummy output",
         "progress": None,
     }
@@ -116,6 +121,7 @@ def test_statement_from_json_no_progress(mocker):
         session_id,
         statement_id=10,
         state=StatementState.RUNNING,
+        code="dummy code",
         output=Output.from_json.return_value,
         progress=None,
     )
@@ -131,6 +137,7 @@ def test_statement_from_json_with_progress(mocker):
     statement_json = {
         "id": 10,
         "state": "running",
+        "code": "dummy code",
         "output": "dummy output",
         "progress": 0.5,
     }
@@ -139,6 +146,7 @@ def test_statement_from_json_with_progress(mocker):
         session_id,
         statement_id=10,
         state=StatementState.RUNNING,
+        code="dummy code",
         output=Output.from_json.return_value,
         progress=0.5,
     )


### PR DESCRIPTION
[Statements](https://livy.incubator.apache.org/docs/latest/rest-api.html#statement) include a `code` attribute but it's not present from the `get_statement` function in `pylivy`.  We'd like to use this to be able to hash & cache the original statement once the response is available.