### PR TITLE
Add helper to upload dataframes to an interactive session

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -37,7 +37,7 @@ The :class:`~livy.session.LivySession` class is the main interface provided by
         # Run some code on the remote cluster
         session.run("filtered = df.filter(df.name == 'Bob')")
         # Retrieve the result
-        local_df = session.read("filtered")
+        local_df = session.download("filtered")
 
 Similarly, batch sessions in Livy can be created and managed with the
 :class:`~livy.batch.LivyBatch` class::
@@ -76,7 +76,7 @@ do::
 
     with LivySession.create(LIVY_URL, auth) as session:
         session.run("filtered = df.filter(df.name == 'Bob')")
-        local_df = session.read("filtered")
+        local_df = session.download("filtered")
 
 Custom requests session
 -----------------------

--- a/livy/session.py
+++ b/livy/session.py
@@ -39,7 +39,7 @@ def _spark_serialise_dataframe_code(
         }[session_kind]
     except KeyError:
         raise RuntimeError(
-            f"read not supported for sessions of kind {session_kind}"
+            f"upload not supported for sessions of kind {session_kind}"
         )
     return template.format(spark_dataframe_name)
 

--- a/livy/session.py
+++ b/livy/session.py
@@ -319,6 +319,16 @@ class LivySession:
             raise RuntimeError("statement had no JSON output")
         return _dataframe_from_json_output(output.json)
 
+    def write(self, dataframe_name: str, data: pandas.DataFrame) -> None:
+        """Upload a pandas dataframe to a Spark dataframe in the session.
+
+        :param dataframe_name: The name of the Spark dataframe to create.
+        :param data: The pandas dataframe to upload.
+        """
+        code = _spark_create_dataframe_code(self.kind, dataframe_name, data)
+        output = self._execute(code)
+        output.raise_for_status()
+
     def _execute(self, code: str) -> Output:
         statement = self.client.create_statement(self.session_id, code)
         intervals = polling_intervals([0.1, 0.2, 0.3, 0.5], 1.0)

--- a/livy/session.py
+++ b/livy/session.py
@@ -68,13 +68,14 @@ CREATE_DATAFRAME_TEMPLATE_PYSPARK = """
 {} = spark.read.json(spark.sparkContext.parallelize([{}]))
 """
 CREATE_DATAFRAME_TEMPLATE_SPARKR = """
-_livy_client_temp_filename <- tempfile(fileext=".jsonl")
-_livy_client_temp_file <- file(_livy_client_temp_filename)
-writeLines('{1}', _livy_client_temp_file)
-close(_livy_client_temp_file)
-{0} <- read.json(_livy_client_temp_filename)
-{0}.persist()
-file.remove(_livy_client_temp_filename)
+livy_client_temp_filename <- tempfile(fileext=".jsonl")
+livy_client_temp_file <- file(livy_client_temp_filename)
+writeLines('{1}', livy_client_temp_file)
+close(livy_client_temp_file)
+{0} <- read.json(livy_client_temp_filename)
+persist({0}, "MEMORY_AND_DISK")
+count({0})  # Force loading the data
+file.remove(livy_client_temp_filename)
 """
 
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -115,11 +115,11 @@ def test_session(integration_url, capsys, session_kind, params):
         with pytest.raises(SparkRuntimeError):
             session.run(params.error_code)
 
-        assert session.read("df").equals(RANGE_DATAFRAME)
+        assert session.download("df").equals(RANGE_DATAFRAME)
 
-        session.write("uploaded", RANGE_DATAFRAME)
+        session.upload("uploaded", RANGE_DATAFRAME)
         session.run(params.dataframe_multiply_code)
-        assert session.read("multiplied").equals(RANGE_DATAFRAME * 2)
+        assert session.download("multiplied").equals(RANGE_DATAFRAME * 2)
 
     assert _session_stopped(integration_url, session.session_id)
 
@@ -140,7 +140,9 @@ def test_sql_session(integration_url):
         with pytest.raises(SparkRuntimeError):
             session.run("not valid SQL!")
 
-        assert session.read_sql("SELECT * FROM view").equals(RANGE_DATAFRAME)
+        assert session.download_sql("SELECT * FROM view").equals(
+            RANGE_DATAFRAME
+        )
 
     assert _session_stopped(integration_url, session.session_id)
 


### PR DESCRIPTION
This adds a new method to upload a pandas DataFrame to an interactive Spark session as a Spark dataframe. Similar to the functionality to download a dataframe, this relies on JSON-encoding the contents of the dataframe to send it to the Spark session.

Credit to sparkmagic for inspiring this method, however I've reimplemented it with improved handling of special characters (they could really use some tests - I don't think their uploader into R sessions can work at all).

As part of this PR, I've also renamed `read` to `download` and named the new method `upload` as I prefer the semantics of up/download to read/write. Keen for others' thoughts on this naming, however. (FYI `read` has been retained as a deprecated alias for `download`).

Closes #88.