### PR TITLE
Fix internal mypy error

### DIFF
--- a/livy/client.py
+++ b/livy/client.py
@@ -213,7 +213,7 @@ class LivyClient:
                 f"this version (should be one of {valid_kinds})"
             )
 
-        interactive_session_params = {"kind": kind.value}
+        interactive_session_params: Dict[str, Any] = {"kind": kind.value}
         if heartbeat_timeout is not None:
             interactive_session_params[
                 "heartbeatTimeoutInSecond"


### PR DESCRIPTION
This error only affects type validation internal to pylivy, so does not require a new release.