### PR TITLE
Fix Livy Batch model and tests, resolve Issue #56

### DIFF
--- a/livy/models.py
+++ b/livy/models.py
@@ -190,6 +190,9 @@ class Batch:
     app_id: Optional[str]
     app_info: Optional[dict]
     log: List[str]
+    name: Optional[str]
+    owner: str
+    proxy_user: Optional[str]
     state: SessionState
 
     @classmethod
@@ -199,6 +202,9 @@ class Batch:
             data.get("appId"),
             data.get("appInfo"),
             data.get("log", []),
+            data.get("name"),
+            data.get("owner"),
+            data.get("proxyUser"),
             SessionState(data["state"]),
         )
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -226,6 +226,9 @@ def test_batch_from_json():
         "appInfo": {"key1": "val1", "key2": "val2"},
         "log": ["log1", "log2"],
         "state": "running",
+        "name": "Application name",
+        "owner": "application_owner",
+        "proxyUser": "application_proxy_user"
     }
 
     expected = Batch(
@@ -233,6 +236,9 @@ def test_batch_from_json():
         app_id="application_000000000000_000001",
         app_info={"key1": "val1", "key2": "val2"},
         log=["log1", "log2"],
+        name="Application name",
+        owner="application_owner",
+        proxyUser="application_proxy_user",
         state=SessionState.RUNNING,
     )
 
@@ -243,6 +249,7 @@ def test_batch_from_json_no_optionals():
     batch_json = {
         "id": 2398,
         "state": "starting",
+        "owner": "application_owner"
     }
 
     expected = Batch(
@@ -250,6 +257,7 @@ def test_batch_from_json_no_optionals():
         app_id=None,
         app_info=None,
         log=[],
+        owner="application_owner",
         state=SessionState.STARTING,
     )
 


### PR DESCRIPTION
Hi, this PR resolves the issue #56 by fixing the Livy Batch model and related tests.

The current Batch model is based on the official documentation from Livy at https://livy.incubator.apache.org/docs/latest/rest-api.html, which unfortunately is not inline with the current code of the Livy server. 

The current code of the Livy server already returns "name", "owner" and "proxyUser" information for a batch, but the official documentation is not updated yet. So I patched our current code to reflect the latest changes.