### PR TITLE
Add name to session model

### DIFF
--- a/livy/models.py
+++ b/livy/models.py
@@ -173,6 +173,7 @@ class Session:
     proxy_user: str
     kind: SessionKind
     state: SessionState
+    name: Optional[str] = None
 
     @classmethod
     def from_json(cls, data: dict) -> "Session":
@@ -181,6 +182,7 @@ class Session:
             data["proxyUser"],
             SessionKind(data["kind"]),
             SessionState(data["state"]),
+            data.get('name')
         )
 
 

--- a/livy/models.py
+++ b/livy/models.py
@@ -182,7 +182,7 @@ class Session:
             data["proxyUser"],
             SessionKind(data["kind"]),
             SessionState(data["state"]),
-            data.get('name')
+            data.get("name"),
         )
 
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -62,10 +62,16 @@ def test_session_from_json_with_name():
         "proxyUser": "user",
         "kind": "pyspark",
         "state": "idle",
-        "name": "example_livy_session"
+        "name": "example_livy_session",
     }
 
-    expected = Session(5, "user", SessionKind.PYSPARK, SessionState.IDLE, name="example_livy_session")
+    expected = Session(
+        5,
+        "user",
+        SessionKind.PYSPARK,
+        SessionState.IDLE,
+        name="example_livy_session",
+    )
 
     assert Session.from_json(session_json) == expected
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -55,6 +55,21 @@ def test_session_from_json():
     assert Session.from_json(session_json) == expected
 
 
+def test_session_from_json_with_name():
+
+    session_json = {
+        "id": 5,
+        "proxyUser": "user",
+        "kind": "pyspark",
+        "state": "idle",
+        "name": "example_livy_session"
+    }
+
+    expected = Session(5, "user", SessionKind.PYSPARK, SessionState.IDLE, name="example_livy_session")
+
+    assert Session.from_json(session_json) == expected
+
+
 def test_statement_from_json_no_output():
 
     session_id = 5

--- a/tox.ini
+++ b/tox.ini
@@ -23,7 +23,7 @@ skip_install = True
 deps =
     mypy
 commands =
-    mypy {posargs:.}
+    mypy --install-types --non-interactive {posargs:.}
 
 [testenv:black]
 skip_install = True


### PR DESCRIPTION
* Adds the session `name` to the session model
* Updates the `from_json` session model to use the `name` if it is provided in the livy API response
* Updates failing mypy test to include missing types (this failure seems to be unrelated to the changes above)